### PR TITLE
Fixing `totalPages` when `onlyMetadata` flag is given

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/cli",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "main": "index.js",
   "repository": "git@github.com:nevermined-io/cli.git",
   "author": "Nevermined",

--- a/src/commands/assets/searchAsset.ts
+++ b/src/commands/assets/searchAsset.ts
@@ -17,13 +17,15 @@ export const searchAsset = async (
 
   logger.info(chalk.dim(`Search using query: ${chalk.green(query)}`))
 
+  logger.debug(chalk.dim(`Using Marketplace API: ${config.nvm.marketplaceUri}`))  
+
   const queryResults = await nvm.assets.search(query, argv.offset, argv.page)
   let metadataResult
 
   if (onlyMetadata) {
     metadataResult = {
       page: queryResults.page,
-      totalPages: queryResults.page,
+      totalPages: queryResults.totalPages,
       totalResults: queryResults.totalResults,
       results: queryResults.results.map((ddo) => {
         const service: ServiceMetadata = ddo.findServiceByType(


### PR DESCRIPTION
## Description

In assets search, when `--onlyMetadata` flag is given the `totalPages` was incorrect

## Is this PR related with an open issue?

Related to Issue #79

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

